### PR TITLE
docs: replace HTML placeholder with proper README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,104 @@
-<!DOCTYPE html>
-<html lang="en">
+# ale-sanchez-g.github.io
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Alejandro Sanchez-Giraldo</title>
-    <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
-</head>
-<header class="mega-menu">
-    <div class="logo">
-        <img src="/img/cap.png" alt="Logo">
-    </div>
-    <div class="burger">
-        <svg height="40px" width="40px" fill="none" stroke="white" stroke-width="2">
-            <line x1="0" y1="5" x2="40" y2="5" />
-            <line x1="0" y1="20" x2="40" y2="20" />
-            <line x1="0" y1="35" x2="40" y2="35" />
-        </svg>
-    </div>
-    <div class="mobile-menu">
-        <div class="cross">
-            <svg height="20px" width="20px" fill="none" stroke="white" stroke-width="2">
-                <line x1="0" y1="0" x2="20" y2="20" />
-                <line x1="0" y1="20" x2="20" y2="0" />
-            </svg>
-        </div>
-        <nav class="mobile-menu-items">
-                <a href="/">Home</a></br>
-                <a href="/reference/APPS">Apps</a></br>
-                <a href="/reference/WORKEXPERIENCE">Work Experience</a></br>
-                <a href="/reference/PUBLICATIONS">Publications</a></br>
-                <a href="/reference/CONFERENCES">Conferences</a></br>
-                <a href="/reference/LEARNING">Learning</a></br>
-                <a href="/support/SUPPORTLIST">Support</a>
-        </nav>
-    </div> 
-</header>
-<body>   
-<div class="mega-menu-2">
-    <nav class="menu-items">
-        <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/reference/APPS">Home</a></li>
-            <li><a href="/reference/WORKEXPERIENCE">Work Experience</a></li>
-            <li><a href="/reference/PUBLICATIONS">Publications</a></li>
-            <li><a href="/reference/CONFERENCES">Conferences</a></li>
-            <li><a href="/reference/LEARNING">Learning</a></li>
-            <li><a href="/support/SUPPORTLIST">Support</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="badges">
-        <a href="https://www.credly.com/badges/5461b72b-82ec-4fec-b779-35eb078f5ceb/linked_in?t=s0sy54">
-            <img src="img/dynaBadge.png" height="30px" alt="Dynatrace Associate" />
-        </a>
-        <a
-            href="https://learn.microsoft.com/en-gb/training/achievements/learn.github.github-actions-automate-tasks.badge?username=AlejandroSG-3988&sharingId=7539A66B782C7D61">
-            <img src="https://learn.microsoft.com/en-us/training/achievements/github/github-actions-automate-tasks.svg"
-                height="30px" alt="Github Actions - automation">
-        </a>
-        <a
-            href="https://learn.microsoft.com/api/achievements/share/en-gb/AlejandroSG-3988/FZD6SK5X?sharingId=7539A66B782C7D61">
-            <img src="https://learn.microsoft.com/en-us/training/achievements/github/github-actions-ci.svg"
-                height="30px" alt="Github Actions - workflows">
-        </a>
-        <a href="https://verify.skilljar.com/c/cvjv4kdfwztp">
-            <img src="img/ldGold.png" height="30px" alt="LaunchDarkly Gold">
-        </a>
-    </div>
-</div>
-<div class="container">
-    <div class="column">🛠️ Helping Teams Engineer Quality</div>
-    <div class="column">🗣️ Product Owner for Quality</div>
-    <div class="column">👁️ Head of Quality Engineering and Observability</div>
-</div>
-<div class="container">
-    <a href="https://www.linkedin.com/in/alejandrosanchezgiraldo">
-        <img src="img/linkedin-black.svg" height="30px" alt="linkedin" />
-    </a>
-</div>
-<div class="container">
-    <p>
-        <strong>Personal Statement: </strong>
-        I am an accomplished Product Owner for Quality with a profound dedication to embedding engineering excellence
-        into
-        all
-        aspects of my work. I firmly hold the belief that quality should be upheld as a collective responsibility, and I
-        derive
-        great satisfaction from collaborating with teams to foster a culture rooted in exceptional standards. Moreover,
-        I am
-        a
-        staunch advocate for data-driven decision-making, recognizing it as the sole influencer essential for the
-        triumph of
-        any
-        product.
+Personal portfolio website for Alejandro Sanchez-Giraldo — Product Owner for Quality with 15+ years of engineering experience across Telecommunications, Airlines, Media, Loyalty, Insurance, Financial Services, and AgriTech.
 
-        With over 15 years of invaluable experience, I have built my expertise in developing engineering capabilities
-        across
-        a
-        diverse range of industries. My professional journey has encompassed sectors including Telecommunications,
-        Airlines,
-        Media, Loyalty, Insurance, Financial Services, and AgriTech, in both Enterprise and Start-up environments. This
-        extensive background has allowed me to gain comprehensive insights into the unique challenges and intricacies
-        associated
-        with each industry, equipping me with a versatile skill set that adapts to various organizational landscapes.
-    </p>
-</div>
-<div class="container">
-    <p>
-        In addition to my extensive experience, I have developed a keen interest in emerging fields and technologies
-        that
-        are
-        shaping the future of engineering. I have actively pursued knowledge and expertise in areas such as Artificial
-        Intelligence (AI), Prompt Engineering, Observability, and Community engagement. These areas have become integral
-        components of my professional growth, as I recognize their potential to revolutionize the way we approach
-        quality
-        engineering and product development. By staying ahead of the latest advancements and actively engaging with
-        communities
-        of like-minded professionals, I continually strive to expand my horizons and contribute to the forefront of
-        cutting-edge
-        engineering practices.
-    </p>
-</div>
-<div class="container">
-    <h2> Achievements </h2>
-</div>
-<div class="container">
-    <ul>
-        <li>📈 Create and deliver a strategic roadmap to evolve from testing services into Quality Engineering
-            capabilities</li>
-        <li>🙋‍♂️ Leading and developing teams towards building quality in their delivery process.</li>
-        <li>🛠️ Exploring DevSecOps tools to enable self-service for quality capabilities.</li>
-        <li>👁️ Strengthening Observability practices to enable faster and secure engineering</li>
-    </ul>
-</div>
+## Tech Stack
 
-<footer class="footer">
-    <nav class="menu-items">
-        <ul>
-            <li><a href="https://github.com/ale-sanchez-g">GitHub Profile</a></li>
-        </ul>
-    </nav>
-</footer>
-<script src="/assets/js/main.js"></script>
-</body>
-<html>
+- **Frontend:** Static HTML, CSS, vanilla JavaScript
+- **Hosting:** GitHub Pages
+- **SEO/Sitemap:** Jekyll (`jekyll-seo-tag`, `jekyll-sitemap`)
+- **Testing:** Playwright (visual regression, desktop + mobile)
+- **CI/CD:** GitHub Actions
+
+## Site Structure
+
+```
+/
+├── index.html                  # Home page (personal statement, badges, achievements)
+├── reference/
+│   ├── work-experience.html    # Career history
+│   ├── publications.html       # Written publications
+│   ├── conferences.html        # Conference talks and appearances
+│   ├── learning.html           # Learning resources and certifications
+│   ├── apps.html               # Projects and tools
+│   └── sums/                   # Event summaries (e.g. AWS Observability Day)
+├── support/
+│   ├── support-list.html       # Support materials index
+│   └── fake-numbers.html       # Fake phone number utility
+├── people/
+│   └── connections.html        # Professional connections
+├── assets/
+│   ├── css/style.css           # Global styles
+│   └── js/main.js              # Mobile menu toggle
+└── img/                        # Images and badge icons
+```
+
+## Local Development
+
+Requires Python 3 (for the dev server) and Node.js 20+.
+
+```bash
+# Install test dependencies
+npm install
+
+# Start the local server on http://localhost:8765
+npm run serve
+```
+
+Open `http://localhost:8765` in your browser.
+
+## Testing
+
+Visual regression tests run against both Desktop Chrome (1280×900) and Mobile Chrome (Pixel 5 viewport) using Playwright.
+
+```bash
+# Run all Playwright tests
+npm test
+
+# Run visual regression tests only
+npm run test:visual
+
+# Update baseline snapshots (after intentional UI changes)
+npm run test:update
+```
+
+Snapshots are stored in `tests/snapshots/` and committed to the repository. A 2% pixel-diff tolerance is applied to account for minor rendering differences.
+
+## CI/CD — GitHub Actions
+
+The `visual-tests.yml` workflow runs on every push and on pull requests targeting `main`.
+
+| Trigger | Behaviour |
+|---------|-----------|
+| Push to any branch | Generates/updates baseline snapshots and commits them back to the branch |
+| Pull request to `main` | Compares against existing baselines and posts a summary comment on the PR |
+| Manual dispatch | Optionally regenerates all baselines via `update_snapshots` input |
+
+Pages covered by visual tests:
+
+- Home
+- Work Experience
+- Publications
+- Conferences
+- Learning Resources
+- Apps
+- AWS Observability Day summary
+- Support Materials
+- Fake Phone Numbers
+- Connections
+
+Artifacts (HTML report + screenshots) are retained for 30 days. If a visual regression is detected the workflow fails and diff images are available under `test-results/` in the uploaded artifact.
+
+## Jekyll Configuration
+
+`_config.yml` is minimal — it sets the site title and description used by the SEO and sitemap plugins:
+
+```yaml
+title: Engineering quality with your team
+description: automation, performance, observability, and more
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+```
+
+GitHub Pages builds the site automatically on every push to `main`.


### PR DESCRIPTION
Adds a real README covering site structure, tech stack, local dev setup,
testing commands, CI/CD workflow behaviour, and Jekyll configuration.

https://claude.ai/code/session_01ViBd97YbSd7ipAHiVg6jqU